### PR TITLE
add missing Input/Output annotation to make plugin work with gradle 7+ projects

### DIFF
--- a/src/main/groovy/com/epam/deltix/gradle/plugins/velocity/VelocityEntry.groovy
+++ b/src/main/groovy/com/epam/deltix/gradle/plugins/velocity/VelocityEntry.groovy
@@ -16,12 +16,17 @@
  */
 package com.epam.deltix.gradle.plugins.velocity
 
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+
 /**
  * Created by PastushenyaV on 7/26/2016.
  */
 class VelocityEntry {
     final String name
+    @InputFile
     String from
+    @OutputFile
     String to           //can be with parameters @{param_name}
     List<Map> contexts
 

--- a/src/main/groovy/com/epam/deltix/gradle/plugins/velocity/VelocityTask.groovy
+++ b/src/main/groovy/com/epam/deltix/gradle/plugins/velocity/VelocityTask.groovy
@@ -20,6 +20,8 @@ import org.apache.velocity.VelocityContext
 import org.apache.velocity.app.VelocityEngine
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -27,7 +29,9 @@ import org.gradle.api.tasks.TaskAction
  */
 class VelocityTask extends DefaultTask {
 
+    @InputFile
     String from
+    @OutputFile
     String to           //can be with parameters @{param_name}
     private Set<VelocityContext> velocityContexts = new HashSet<>()
 


### PR DESCRIPTION
Problem:

Using this plugin in project with gradle 7+ throws following error:
```
Some problems were found with the configuration of task 'binOpvelocity' (type 'VelocityTask').
  - In plugin 'velocity' type 'com.epam.deltix.gradle.plugins.velocity.VelocityTask' property 'from' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.1.1/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'velocity' type 'com.epam.deltix.gradle.plugins.velocity.VelocityTask' property 'to' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.1.1/userguide/validation_problems.html#missing_annotation for more details about this problem.
```